### PR TITLE
Add ignore case option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ available, but can be easily remapped.
 This plugin was not tested and is not expected to work with `foldmethod` set to
 `manual` for now.
 
+## Configuration
+
+You can ignore case when sorting by modifying this variable:
+```vim
+let g:sort_folds_ignore_case = 1
+```
+Default is `0`
 
 ## Python 3
 

--- a/doc/SortFolds.txt
+++ b/doc/SortFolds.txt
@@ -1,4 +1,4 @@
-*SortFolds.txt*	For Vim version 8.0	Last change: 2018 October 11
+*SortFolds.txt*	For Vim version 8.0	Last change: 2020 September 16
 
 Version: 1.0.0
 Author : Oliver Breitwieser <oliver.breitwieser@gmail.com>
@@ -52,6 +52,15 @@ SORTING BY OTHER LINES IN FOLD          *SortFolds-custom-sort-line*
     based on the 42th line you would map:
 >
     vmap <silent> <Leader>sf :call SortFolds#SortFolds(41)<CR>
+
+==============================================================================
+CONFIGURATION                           *SortFolds-configuration*
+
+    You can ignore case when sorting by modifying this variable:
+>
+    let g:sort_folds_ignore_case = 1
+<
+    Default is 0
 
 ==============================================================================
 REQUIREMENTS                            *SortFolds-requirements*

--- a/plugin/SortFolds.vim
+++ b/plugin/SortFolds.vim
@@ -17,6 +17,10 @@ if !has("python3")
     finish
 endif
 
+if !exists("g:sort_folds_ignore_case")
+  let g:sort_folds_ignore_case = 0
+endif
+
 vnoremap <silent> <Plug>SortFolds :call SortFolds#SortFolds()<CR>
 
 if !hasmapto("<Plug>SortFolds", "v")

--- a/pythonx/SortFolds/__init__.py
+++ b/pythonx/SortFolds/__init__.py
@@ -67,7 +67,8 @@ def debug(sorting_line_number=1):
     print("#  Sorted  #")
     print("############")
 
-    sorted_folds = sorted(get_folds(), key=lambda f: f[sorting_line_number])
+    sorted_folds = sorted(get_folds(),
+                          key=get_fold_to_sort_key(sorting_line_number))
     print_folds(sorted_folds)
 
 
@@ -215,8 +216,16 @@ def print_folds(folds):
             print(fold.level, line)
 
 
+def get_fold_to_sort_key(sort_line):
+    ignore_case = vim.eval("g:sort_folds_ignore_case")
+    if ignore_case == "0":
+        return lambda f: f[sort_line]
+    else:
+        return lambda f: f[sort_line].casefold()
+
+
 def sort_folds(sort_line=0):
-    sorted_folds = sorted(get_folds(), key=lambda f: f[sort_line])
+    sorted_folds = sorted(get_folds(), key=get_fold_to_sort_key(sort_line))
 
     sorted_lines = list(it.chain(*list(map(lambda f: f.lines, sorted_folds))))
     vim.current.range[:] = sorted_lines


### PR DESCRIPTION
I don't know if this is of any interest to you, but I needed to be able to sort case insensitive. I'm no python or vimscript wizard but this has worked for me pretty well. Love your plugin, saved me a lot of time.